### PR TITLE
Do not convert double pipes in style and code tags

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -18,5 +18,5 @@ Carbon:
   Hyphen:
     Shy:
       # Which string should be replaced with &shy; Please use regex style. For e.g. '||' write '\|\|'
-      replace: '\|\|' 
-      regex: '(?=[^<]*+(?:<(?!\/?(?:textarea|pre|script)\b)[^<]*+)*+(?:<(?>textarea|pre|script)\b|\z))'
+      replace: '\|\|'
+      regex: '(?=[^<]*+(?:<(?!\/?(?:textarea|pre|script|style|code)\b)[^<]*+)*+(?:<(?>textarea|pre|script|style|code)\b|\z))'


### PR DESCRIPTION
To minimize the risk of edge cases I would ignore text in <style> tags. There might be things link `content: '||';`.

If ever used, the <code> tag is very likely to has || as logical OR.