### PR TITLE
BUGFIX: Prevent wrapping HTML with HTML/BODY/DOCTYPE

### DIFF
--- a/Classes/Fusion/Implementation.php
+++ b/Classes/Fusion/Implementation.php
@@ -107,7 +107,8 @@ class Implementation extends AbstractFusionObject
         }
 
         $syllable = new Syllable($language);
-
+        $syllable->setLibxmlOptions(LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        
         $syllable->getSource()->setPath($this->languagesDirectory);
         $syllable->getCache()->setPath($cacheDirectory);
 


### PR DESCRIPTION
Without these flags, the HTML output get's wrapped with HTML/BODY and DOCTYPE. This results in invaild HTML if you try to hyphenate partial HTML blocks.

See also:
https://github.com/vanderlee/phpSyllable/blob/master/tests/SyllableTest.php#L217-L229