### PR TITLE
TASK: Adaption to the latest features of vanderlee/syllable

### DIFF
--- a/Classes/Fusion/Implementation.php
+++ b/Classes/Fusion/Implementation.php
@@ -107,8 +107,7 @@ class Implementation extends AbstractFusionObject
         }
 
         $syllable = new Syllable($language);
-        $syllable->setLibxmlOptions(LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-        
+
         $syllable->getSource()->setPath($this->languagesDirectory);
         $syllable->getCache()->setPath($cacheDirectory);
 
@@ -117,9 +116,7 @@ class Implementation extends AbstractFusionObject
 
         switch ($this->getType()) {
             case 'html':
-                $html = '<div>' . mb_convert_encoding($this->getContent(), 'HTML-ENTITIES', "UTF-8") . '</div>';
-                $result = $syllable->hyphenateHtml($html);
-                $result = substr(trim($result), 5, -6);
+                $result = $syllable->hyphenateHtmlText($this->getContent());
                 break;
             case 'test':
                 // Break missing intendedly

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "neos/flow": "*",
         "neos/fusion": "^4.3 || ^5.0 || ^7.0 || ^8.0",
-        "vanderlee/syllable": "^1.5"
+        "vanderlee/syllable": "^1.7"
     },
     "authors": [
         {


### PR DESCRIPTION
Hi @jonnitto ,

this PR is mainly about the correct handling of UTF-8 character sets when hyphenating HTML. It previously differed from the handling of hyphenating plain text and required some extra steps to handle special characters. HTML hyphenation does not require the expensive `mb_convert_encoding` anymore not does it transform the original UTF-8 characters in any way. For example
```
<p>Надзвичайно <strong>складний</strong> метатекст.</p>
```
was previously transformed into
```
<p>&#1053;&#1072;&#1076;&shy;&#1079;&#1074;&#1080;&shy;&#1095;&#1072;&#1081;&#1085;&#1086; <strong>&#1089;&#1082;&#1083;&#1072;&shy;&#1076;&#1085;&#1080;&#1081;</strong> &#1084;&#1077;&shy;&#1090;&#1072;&shy;&#1090;&#1077;&shy;&#1082;&#1089;&#1090;.</p>
```
and is now to
```
<p>Над&shy;зви&shy;чайно <strong>скла&shy;дний</strong> ме&shy;та&shy;те&shy;кст.</p>
```

Greetings
Alex


